### PR TITLE
Update item URL and name

### DIFF
--- a/themes/gatsby-theme-service-relief/src/pages/index.js
+++ b/themes/gatsby-theme-service-relief/src/pages/index.js
@@ -93,11 +93,11 @@ const IndexPage = ({ data: { site, allAirtable: { nodes: entities }}}) => {
                 <li key={entity.data.BusinessName}>
                   <a
                     className="underline"
-                    href={entity.data.BusinessUrl}
+                    href={entity.data.FundraiserUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {entity.data.BusinessName}
+                    {entity.data.FundraiserTitle}
                   </a>{" "}
                   {entity.data.FundraiserDescription && (
                     <p className="mt-2 italic">


### PR DESCRIPTION
These are the items that are (currently) required by the Airtable form. Alternatively, we can change the base Airtable template to use the business URL and name, whichever is most appropriate.