### PR TITLE
Add padding to container

### DIFF
--- a/themes/gatsby-theme-service-relief/tailwind.config.js
+++ b/themes/gatsby-theme-service-relief/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   theme: {
+    container: {
+      padding: "1rem"
+    },
     screens: {
       sm: "640px",
       md: "768px",


### PR DESCRIPTION
The container is really tight on mobile without some padding.

Before:

<img width="420" alt="Screen Shot 2020-03-20 at 6 29 29 PM" src="https://user-images.githubusercontent.com/3457341/77215268-cfccb100-6ad8-11ea-9d35-c28e9063dfe6.png">

After:

<img width="423" alt="Screen Shot 2020-03-20 at 6 29 41 PM" src="https://user-images.githubusercontent.com/3457341/77215276-d824ec00-6ad8-11ea-97d4-c26ce95601b9.png">

